### PR TITLE
Remove REBAR_CACHE_DIR for now.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,7 +7,3 @@ if [[ ! -x "$REBAR3_PATH/rebar3" ]]; then
 fi
 
 PATH_add "$REBAR3_PATH"
-
-export REBAR_CACHE_DIR="$(direnv_layout_dir)/rebar_cache"
-
-mkdir -p "$REBAR_CACHE_DIR"


### PR DESCRIPTION
Looks like there is a small bug in rebar3 when using REBAR_CACHE_DIR.  It places the hex.config in the cache rather than the configuration which causes anything related to the hex plugin to fail due to the authentication not being found.